### PR TITLE
Pass LS_HEAP_SIZE to logstash start script

### DIFF
--- a/app-misc/logstash-bin/files/logstash.confd
+++ b/app-misc/logstash-bin/files/logstash.confd
@@ -3,3 +3,6 @@
 
 # Name of the gentoo java vm to use instead of the current vm
 # JAVA_VM=
+
+# Maximum heap size to use.  It's passed to JVM with `-Xmx` option.
+#LS_HEAP_SIZE=128m

--- a/app-misc/logstash-bin/files/logstash.initd
+++ b/app-misc/logstash-bin/files/logstash.initd
@@ -15,6 +15,7 @@ start() {
 	[[ "${JAVA_VM}" ]] && export JAVA_HOME=$(java-config --select-vm ${JAVA_VM} -o)
 
 	export JAVA_OPTS="-Des.path.home=/var/lib/logstash/elasticsearch"
+	[[ ${LS_HEAP_SIZE} ]] && export LS_HEAP_SIZE
 
 	start-stop-daemon --start --exec ${LOGSTASH_BIN} \
 		--make-pidfile --pidfile /run/logstash.pid \


### PR DESCRIPTION
LS_HEAP_SIZE could be set in confd file (`/etc/conf.d/logstash`) to limit memory use.